### PR TITLE
Added comments for username login to example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ var config = {
     userDB: 'sl-users',
     couchAuthDB: '_users'
   },
+  // login with username is disabled by default
+  // uncomment this if you want to enable it
+  // local: {
+  //   emailUsername: false, // store the username in the database instead of an auto-generated key
+  //   usernameLogin: true, // allow login with username
+  // },
   mailer: {
     fromEmail: 'gmail.user@gmail.com',
     options: {


### PR DESCRIPTION
I was having some trouble setting the project up. I was expecting username login to work out of the box.
The errors I got were confusing. First I got `no matching identifier` and later `invalid username or password`.
Especially since the README mentions logging in with username and password.

I had to dive into the code to find the missing options.
To avoid this kind of confusion I thought mentioning the necessary options in the example config could help new users and prevent frustration.