### PR TITLE
:bug: :recycle: #49: improve `removeExpiredKeys`

### DIFF
--- a/src/template-utils.ts
+++ b/src/template-utils.ts
@@ -8,7 +8,7 @@ import { join } from 'path';
  * Note that they must be greedy (*?) to format the markdown correctly.
  * @param text the markdown text to process
  */
-function processMarkdown(text: string) {
+function processMarkdown(text: string): string {
   return text
     .replace(/(\s)\*\*(.*?)\*\*(\s)/gim, '$1<b>$2</b>$3')
     .replace(/(\s)\_(.*?)\_(\s)/gim, '$1<i>$2</i>$3')

--- a/src/types/typings.ts
+++ b/src/types/typings.ts
@@ -6,6 +6,8 @@ export interface IdentifiedObj {
   type: string;
 }
 
+export type SessionCleanupType = 'all' | 'expired' | 'other';
+
 /** copied from https://nodemailer.com/smtp/pooled/ because it's not included in the typings */
 export interface PooledSMTPOptions {
   /** set to true to use pooled connections (defaults to false) instead of creating a new connection for every email */

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,7 +16,7 @@ export function URLSafeUUID(): string {
   return URLSafeBase64.encode(uuidv4(null, Buffer.alloc(16)));
 }
 
-export function getSessionKey() {
+export function getSessionKey(): string {
   let token = URLSafeUUID();
   // Make sure our token doesn't start with illegal characters
   while (token[0] === '_' || token[0] === '-') {
@@ -25,7 +25,7 @@ export function getSessionKey() {
   return token;
 }
 
-function getUserKey() {
+function getUserKey(): string {
   return URLSafeUUID().substring(0, 8).toLowerCase();
 }
 
@@ -37,7 +37,7 @@ export function generateSlUserKey(): string {
   return newKey;
 }
 
-export function hyphenizeUUID(uuid: string) {
+export function hyphenizeUUID(uuid: string): string {
   return (
     uuid.substring(0, 8) +
     '-' +
@@ -55,7 +55,7 @@ export function removeHyphens(uuid: string) {
   return uuid.split('-').join('');
 }
 
-export function hashToken(token: string) {
+export function hashToken(token: string): string {
   return crypto.createHash('sha256').update(token).digest('hex');
 }
 
@@ -63,7 +63,7 @@ export function putSecurityDoc(
   server: ServerScope,
   db: DocumentScope<any>,
   doc
-) {
+): Promise<any> {
   // @ts-ignore
   return server.request({
     db: db.config.db,
@@ -161,7 +161,7 @@ export function getSessionToken(req: Request) {
 /**
  * Generates views for each registered provider in the user design doc
  */
-export function addProvidersToDesignDoc(config: Partial<Config>, ddoc: any) {
+export function addProvidersToDesignDoc(config: Partial<Config>, ddoc: any): any {
   const providers = config.providers;
   if (!providers) {
     return ddoc;
@@ -178,14 +178,14 @@ export function addProvidersToDesignDoc(config: Partial<Config>, ddoc: any) {
 }
 
 /** Capitalizes the first letter of a string */
-export function capitalizeFirstLetter(str: string) {
+export function capitalizeFirstLetter(str: string): string {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 /**
  * adds the nested properties of `source` to `dest`, overwriting present entries
  */
-export function mergeConfig(dest: any, source: any) {
+export function mergeConfig(dest: any, source: any): any {
   for (const [k, v] of Object.entries(source)) {
     if (typeof dest[k] === 'object' && !Array.isArray(dest[k])) {
       dest[k] = mergeConfig(dest[k], source[k]);
@@ -204,7 +204,7 @@ export function mergeConfig(dest: any, source: any) {
  * @return  resulting array
  */
 
-export function arrayUnion<T>(a: Array<T>, b: Array<T>) {
+export function arrayUnion<T>(a: Array<T>, b: Array<T>): T[] {
   const result = a.concat(b);
   for (let i = 0; i < result.length; ++i) {
     for (let j = i + 1; j < result.length; ++j) {
@@ -220,7 +220,7 @@ export function arrayUnion<T>(a: Array<T>, b: Array<T>) {
  * `status`, `error` and optionally one of
  * `validationErrors` or `message`.
  */
-export function isUserFacingError(errObj: any) {
+export function isUserFacingError(errObj: any): boolean {
   if (!errObj || typeof errObj !== 'object') {
     return false;
   }
@@ -242,11 +242,11 @@ export function isUserFacingError(errObj: any) {
   return requiredProps.size === 0;
 }
 
-export function replaceAt(str: string, idx: number, repl: string) {
+export function replaceAt(str: string, idx: number, repl: string): string {
   return str.substring(0, idx) + repl + str.substring(idx + 1, str.length);
 }
 
-export function timeoutPromise(duration) {
+export function timeoutPromise(duration): Promise<unknown> {
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(true);

--- a/test/user.spec.ts
+++ b/test/user.spec.ts
@@ -956,7 +956,7 @@ describe('User Model', async function () {
       .then(function () {
         console.log('Cleaning expired sessions');
         // @ts-ignore
-        return user.logoutUserSessions(testUser, 'expired');
+        return user.dbAuth.logoutUserSessions(testUser, 'expired');
       })
       .then(function (finalDoc) {
         expect(Object.keys(finalDoc.session).length).to.equal(1);


### PR DESCRIPTION
- Use the same method as when calling for a single user to avoid conflicts if the method runs longer
- This way, the expired sessions are correctly documented under `inactiveSessions`. This reduces the number of tombstones  in `_users` 