### PR TITLE
Handle uncaught error sending email during registration and emit event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Here is a full list of the events that CouchAuth emits, and parameters provided:
 - `logout`: (`user_id`)
 - `logout-all`: (`user_id`)
 - `consents`: (`userDoc`)
+- `confirmation-email-error`: (`userDoc`)
 
 ## Main API
 

--- a/src/types/typings.ts
+++ b/src/types/typings.ts
@@ -122,7 +122,8 @@ export type UserEvent =
   | 'forgot-username-attempt'
   | 'email-change-attempt'
   | 'user-db-added'
-  | 'user-deleted';
+  | 'user-deleted'
+  | 'confirmation-email-error';
 
 export interface UserActivity {
   timestamp: string;

--- a/src/user.ts
+++ b/src/user.ts
@@ -409,6 +409,7 @@ export class User {
       }
     }
 
+    // TODO: This is an instance of the promise constructor anti-pattern
     return new Promise(async (resolve, reject) => {
       newUser = await this.prepareNewUser(newUser);
       if (hasError || !this.config.security.loginOnRegistration) {
@@ -472,14 +473,20 @@ export class User {
     const result = await this.userDB.insert(finalNewUser);
     newUser._rev = result.rev;
     if (this.config.local.sendConfirmEmail) {
-      await this.mailer.sendEmail(
-        'confirmEmail',
-        newUser.unverifiedEmail.email,
-        {
-          req: req,
-          user: newUser
-        }
-      );
+      try {
+        await this.mailer.sendEmail(
+          'confirmEmail',
+          newUser.unverifiedEmail.email,
+          {
+            req: req,
+            user: newUser
+          }
+        );
+      }
+      catch (err) {
+        this.emitter.emit('confirmation-email-error', newUser);
+        console.warn('error sending confirmation email to '+newUser.unverifiedEmail?.email, err);
+      }
     }
     return newUser as SlUserDoc;
   }


### PR DESCRIPTION
Fixes #71 
During user creation, an exception while sending the confirmation email would hang express. Wrap the email confirmation sending in try/catch. Emit event 'confirmation-email-error' if mail fails to send.

I also noted that the promise returned by createUser() is a promise-constructor anti-pattern, exceptions thrown by prepareNewUser() and insertNewUserDocument() might also hang Express. Though I'm not sure what those exceptions might be.
