### PR TITLE
Add 'useCustomMailer' and 'sendExistingUserEmail' config options

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -48,6 +48,8 @@ const exampleConfig = {
     sendPasswordChangedEmail: true,
     // If this is set, the user will be redirected to this location after confirming email instead of JSON response
     confirmEmailRedirectURL: '/',
+    // Send an email if the user tried to signup with an existing email
+    sendExistingUserEmail: true,
     // Set this to true to disable usernames and use emails instead
     emailUsername: false,
     // Also return the username and UUID when creating a session
@@ -102,6 +104,8 @@ const exampleConfig = {
     couchAuthOnCloudant: false
   },
   mailer: {
+    // If you want to use the built in mailer or a custom one. If you want to use the custom one, you need to listen to the emitted events
+    useCustomMailer: false,
     // Email address that all your system emails will be from
     fromEmail: 'noreply@example.com',
     // Use this if you want to specify a custom Nodemailer transport. Defaults to SMTP or sendmail.

--- a/src/config/default.config.ts
+++ b/src/config/default.config.ts
@@ -40,7 +40,8 @@ export const defaultConfig: Config = {
     requireEmailConfirm: true,
     sendConfirmEmail: true,
     requirePasswordOnEmailChange: true,
-    sendPasswordChangedEmail: true
+    sendPasswordChangedEmail: true,
+    sendExistingUserEmail: true,
   },
   dbServer: {
     protocol: 'http://',

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -151,7 +151,7 @@ export interface LocalConfig {
    */
   confirmEmailRedirectURL?: string;
   /** Send an email if the user tried to signup with an existing email */
-  sendExistingUserEmail: true
+  sendExistingUserEmail?: true
   /** allow to also login with the username. Default: `false` */
   usernameLogin: boolean;
   /** allow to also login with the UUID. Default: `false` */
@@ -285,7 +285,7 @@ export interface RetryMailOptions {
 /** Configure how [nodemailer](https://nodemailer.com/about/) sends mails. */
 export interface MailerConfig {
   /** If you want to use the built in mailer or a custom one. If you want to use the custom one, you need to listen to the emitted events */
-  useCustomMailer: boolean;
+  useCustomMailer?: boolean;
   /** Email address that all your system emails will be from */
   fromEmail: string | Address;
   /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -150,6 +150,8 @@ export interface LocalConfig {
    * confirming email instead of JSON response
    */
   confirmEmailRedirectURL?: string;
+  /** Send an email if the user tried to signup with an existing email */
+  sendExistingUserEmail: true
   /** allow to also login with the username. Default: `false` */
   usernameLogin: boolean;
   /** allow to also login with the UUID. Default: `false` */
@@ -282,6 +284,8 @@ export interface RetryMailOptions {
 
 /** Configure how [nodemailer](https://nodemailer.com/about/) sends mails. */
 export interface MailerConfig {
+  /** If you want to use the built in mailer or a custom one. If you want to use the custom one, you need to listen to the emitted events */
+  useCustomMailer: boolean;
   /** Email address that all your system emails will be from */
   fromEmail: string | Address;
   /**


### PR DESCRIPTION
Adds option for using a custom mailer by listening to the emitted events, instead of using the built in mailer.